### PR TITLE
fix: Resolves issue 1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>me.mtk.torrey</groupId>
   <artifactId>torreyc</artifactId>
-  <version>3.0.0</version>
+  <version>3.0.1</version>
 
   <name>torrey</name>
   <!-- FIXME change it to the project's website -->

--- a/src/main/java/me/mtk/torrey/Torrey.java
+++ b/src/main/java/me/mtk/torrey/Torrey.java
@@ -11,7 +11,7 @@ import me.mtk.torrey.backend.targets.Targets;
 public final class Torrey
 {
     // The semantic version number of the compiler.
-    public static String SEMANTIC_VERSION = "3.0.0";
+    public static String SEMANTIC_VERSION = "3.0.1";
 
     public static void main(String ... args)
     {

--- a/src/main/java/me/mtk/torrey/frontend/analysis/TypeCheckerVisitor.java
+++ b/src/main/java/me/mtk/torrey/frontend/analysis/TypeCheckerVisitor.java
@@ -210,6 +210,13 @@ public final class TypeCheckerVisitor implements ASTNodeVisitor<DataType>
 
             // Type check child expression.
             childExpr.accept(this);
+
+            if (childExpr.evalType() == DataType.UNDEFINED)
+                reporter.error(
+                    childExpr.token(), 
+                    ErrorMessages.UndefinedOperandToPrint, 
+                    childExpr.token().rawText());
+
         }
         
         return DataType.UNDEFINED;

--- a/src/main/java/me/mtk/torrey/frontend/error_reporter/ErrorMessages.java
+++ b/src/main/java/me/mtk/torrey/frontend/error_reporter/ErrorMessages.java
@@ -37,4 +37,5 @@ public final class ErrorMessages
         + " identifier '%s' cannot be of type '%s'";
     public static final String ExpectedExprOrStmt = "Expected the start of an"
         + " expression or statement but found '%s' instead";
+    public static final String UndefinedOperandToPrint = "Cannot print operand '%s' because it does not evaluate to a known type";
 }


### PR DESCRIPTION
Fixes the issue where the compiler throws a NullPointerException with
nested print expressions. This fix simply throws a semantic error to
standard error stream if this occurs. In the future, this could be
changed to simply log the data type "null" or "undefined" to standard
output instead of showing a semantic error message.